### PR TITLE
switch to using yt_dlp which is not stagnant

### DIFF
--- a/code/mopidy/mopidymixcloud/mopidy_mixcloud/mixcloud_data.py
+++ b/code/mopidy/mopidymixcloud/mopidy_mixcloud/mixcloud_data.py
@@ -2,7 +2,7 @@ from mopidy.models import Ref,Track,Album,Artist
 import requests
 import urllib
 import sys
-import youtube_dl
+import yt_dlp
 from .util import LocalData,MixcloudException
 from .uris import *
 # backwards compatibility
@@ -191,7 +191,7 @@ def get_refs_for_uri(uri,max_tracks):
     return get_tracks_refs_for_uri(uri,max_tracks)[1]
 
 # get stream url
-ydl=youtube_dl.YoutubeDL()
+ydl=yt_dlp.YoutubeDL()
 def get_stream_url(uri):
     url=cache.urls.get(uri)
     if url is not None:

--- a/code/mopidy/mopidymixcloud/setup.py
+++ b/code/mopidy/mopidymixcloud/setup.py
@@ -31,7 +31,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0',
         'Pykka >= 1.1',
-        'youtube-dl >= 2020.6.16.1'
+        'yt_dlp >= 2023.9.24'
     ],
     entry_points={
         'mopidy.ext': [


### PR DESCRIPTION
youtube-dl no longer works with mixcloud due to changes to urls i.e. https://github.com/yt-dlp/yt-dlp/issues/8104 - it relies on youtube-dl to get the content however youtube-dl has not been kept up to date with fixes and therefore this change adds support for switching to yt_dlp which has a much more active community.
